### PR TITLE
override splitting of field names passed to get_field2

### DIFF
--- a/HariSekhonUtils.pm
+++ b/HariSekhonUtils.pm
@@ -1659,7 +1659,7 @@ sub isInterface ($) {
     my $interface = shift;
     defined($interface) || return undef;
     # TODO: consider checking if the interface actually exists on the system
-    $interface =~ /^((?:eth|bond|lo)\d+|lo)$/ or return undef;
+    $interface =~ /^((?:em|eth|bond|lo)\d+|lo)$/ or return undef;
     return $1;
 }
 


### PR DESCRIPTION
There are cases where we want to prevent splitting of field names that
contain dot.  For example, when this is used in
check_hadoop_namenode_state.pl, Cloudera uses the field tag.HAState in
the jmx and we don’t want to split on the dot, otherwise the field
contents never get found.
