### PR TITLE
allow user/host.name as valid principal

### DIFF
--- a/HariSekhonUtils.pm
+++ b/HariSekhonUtils.pm
@@ -1800,7 +1800,7 @@ sub isJson($){
 sub isKrb5Princ ($) {
     my $principal = shift;
     defined($principal) or return undef;
-    $principal =~ /^($krb5_principal_regex)$/ or return undef;
+    $principal =~ m%^($krb5_principal_regex(:?/[-\.a-zA-Z0-9]+))$% or return undef;
     return $1;
 }
 


### PR DESCRIPTION
Valid Kerberos principals may consist of an optional component that further identifies the principal.  For example, user/fully.qualified.hostname@EXAMPLE.NET is a valid service principal.  This patch allows more complete validation of principals, necessary for using host-specific principals with harisekhon/nagios-plugins/check_krb5_kdc.pl.
