### PR TITLE
Some characters get url encoded in the cluster name

### DIFF
--- a/HariSekhon/ClouderaManager.pm
+++ b/HariSekhon/ClouderaManager.pm
@@ -398,7 +398,7 @@ sub validate_cm_activity(){
 
 sub validate_cm_cluster(){
     defined($cluster) or usage "cluster not defined";
-    $cluster    =~ /^\s*([\w\s\.-]+)\s*$/ or usage "Invalid cluster name given, may only contain alphanumeric, space, dash, dots or underscores";
+    $cluster    =~ /^\s*([\w\s\%\.-]+)\s*$/ or usage "Invalid cluster name given, may only contain alphanumeric, space, dash, dots or underscores";
     $cluster = $1;
     vlog_option "cluster", $cluster;
     return $cluster;


### PR DESCRIPTION
% is a valid character for names that may include brackets. eg [i] is %5Bi%5D.

A better solution might be to do the encoding within the library but this is enough to make it function with bracket characters.