### PR TITLE
added function curl_redirect

### DIFF
--- a/HariSekhonUtils.pm
+++ b/HariSekhonUtils.pm
@@ -454,6 +454,7 @@ our %EXPORT_TAGS = (
     'web'   =>  [   qw(
                         curl
                         curl_json
+                        curl_redirect
                         wget
                     ) ],
 );
@@ -1462,6 +1463,29 @@ sub curl_json ($;$$$$$$) {
     $json = isJson($content) or quit "CRITICAL", "invalid json returned " . ( $name ? "by $name at $url" : "from $url");
 }
 
+sub curl_redirect ($;$$$$$$) {
+    my $url         = shift;
+    my $name        = shift;
+    my $user        = shift;
+    my $password    = shift;
+    my $err_handler = shift;
+    my $type        = shift() || 'GET';
+    my $body        = shift;
+
+    defined_main_ua();
+    $main::ua->add_handler(response_redirect => sub {
+        my($response, $ua, $h) = @_;
+
+        if ($response->code == 307) {
+            my $active = $response->header("Location");
+            quit("OK", "Standby with active at $active");
+        }
+
+        return undef;
+    });
+
+    return curl $url, $name, $user, $password, $err_handler, $type, $body;
+}
 
 sub debug (@) {
     return unless $debug;


### PR DESCRIPTION
In the case of HA + Kerberos, one faces the problem that a redirect sends one to a host for which one has no suitable certificate. However, a redirect shows that at least the passive side is working (by issuing the redirect), and that is what should be reported by Nagios. This functionality is provided by this new utility function.