### PR TITLE
 Fix for Issue #37 - ElasticSearch --ssl-noverify fails with CRITICAL:  500 SSL_verify_mode must be a number and not a string

### DIFF
--- a/HariSekhon/Elasticsearch.pm
+++ b/HariSekhon/Elasticsearch.pm
@@ -21,7 +21,6 @@ use HariSekhonUtils;
 use Carp;
 use Data::Dumper;
 use LWP::Simple '$ua';
-use IO::Socket::SSL;
 
 set_port_default(9200);
 
@@ -177,7 +176,7 @@ sub curl_elasticsearch_raw($;$$){
     if ($ssl) {
         $protocol = "https";
         if ($ssl_noverify) {
-            $ua->ssl_opts(verify_hostname => 0, SSL_verify_mode => SSL_VERIFY_NONE);
+            $ua->ssl_opts(verify_hostname => 0, SSL_verify_mode => 0);
         }
     }
     if ($user and $password) {

--- a/HariSekhon/Elasticsearch.pm
+++ b/HariSekhon/Elasticsearch.pm
@@ -21,6 +21,7 @@ use HariSekhonUtils;
 use Carp;
 use Data::Dumper;
 use LWP::Simple '$ua';
+use IO::Socket::SSL;
 
 set_port_default(9200);
 
@@ -176,7 +177,7 @@ sub curl_elasticsearch_raw($;$$){
     if ($ssl) {
         $protocol = "https";
         if ($ssl_noverify) {
-            $ua->ssl_opts('SSL_verify_mode' => 'SSL_VERIFY_NONE');
+            $ua->ssl_opts(verify_hostname => 0, SSL_verify_mode => SSL_VERIFY_NONE);
         }
     }
     if ($user and $password) {


### PR DESCRIPTION
tested with centos 6.3 and centos 6.9