### PR TITLE
Skip connection refused to allow checking from different host in a Cassandra cluster

### DIFF
--- a/HariSekhon/Cassandra/Nodetool.pm
+++ b/HariSekhon/Cassandra/Nodetool.pm
@@ -33,6 +33,7 @@ our @EXPORT = ( qw (
                         die_nodetool_unrecognized_output
                         nodetool_options
                         skip_nodetool_output
+			            skip_connection_refused
                         validate_nodetool
                         validate_nodetool_options
                 )
@@ -93,10 +94,9 @@ our $nodetool_errors_regex = qr/
                                 You\s+must\s+set |
                                 Cannot\s+resolve |
                                 unknown\s+host   |
-                                connection\s+refused  |
                                 failed\s+to\s+connect |
-                                error |
-                                user  |
+                                error    |
+                                user     |
                                 password |
                                 Exception(?!s\s*:\s*\d+) |
                                 in thread
@@ -105,7 +105,11 @@ our $nodetool_errors_regex = qr/
 sub check_nodetool_errors($){
     @_ or code_error "no input passed to check_nodetool_errors()";
     my $str = join(" ", @_);
-    quit "CRITICAL", $str if $str =~ /$nodetool_errors_regex/;
+    if(skip_connection_refused($str)) {
+         return 1;
+    }else{
+         quit "CRITICAL", $str if $str =~ /$nodetool_errors_regex/;
+    }
 }
 
 sub skip_nodetool_output($){
@@ -116,6 +120,15 @@ sub skip_nodetool_output($){
         return 1;
     }
     return 0;
+}
+
+sub skip_connection_refused($){
+	@_ or code_error "no input passed to skip_nodetool_output()";
+    	my $str = join(" ", @_);
+	if($str =~ /connection\s+refused/i) {
+		return 1;
+	}
+	return 0;
 }
 
 # Cassandra 2.0 DataStax Community Edition (nodetool version gives 'ReleaseVersion: 2.0.2')


### PR DESCRIPTION
This pull request is needed for the [pull request](https://github.com/HariSekhon/nagios-plugins/pull/202) created in the [nagios-plugins](https://github.com/HariSekhon/nagios-plugins) repository. It allows for skipping connection refuse from one host as long as other hosts can be reached using nodetool. 