### PR TITLE
Update path to perl_cpanm_install_if_absent.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ perl:
 	$(CPANM) -V | head -n2
 
 	@echo "Installing Test::More first because some libraries need this to already be present to build"
-	$(BASH_TOOLS)/perl_cpanm_install_if_absent.sh Test::More
+	$(BASH_TOOLS)/perl/perl_cpanm_install_if_absent.sh Test::More
 
 	@echo
 	# called within cpan target


### PR DESCRIPTION
This was moved to a subdirectory in a change last month - all other references appear to have been updated.

This prevented building on Rocky 8:
```
/usr/bin/cpanm
cpanm -V | head -n2
cpanm (App::cpanminus) version 1.7044 (/usr/bin/cpanm)
perl version 5.026003 (/usr/bin/perl)
Installing Test::More first because some libraries need this to already be present to build
bash-tools/perl_cpanm_install_if_absent.sh Test::More
make[4]: bash-tools/perl_cpanm_install_if_absent.sh: Command not found
make[4]: *** [Makefile:79: perl] Error 127
make[4]: Leaving directory '/root/nagios/Nagios-Plugins/lib'
make[3]: *** [Makefile:58: build] Error 2
make[3]: Leaving directory '/root/nagios/Nagios-Plugins/lib'
make[2]: *** [Makefile:92: perl-libs] Error 2
make[2]: Leaving directory '/root/nagios/Nagios-Plugins'
make[1]: *** [Makefile:86: perl] Error 2
make[1]: Leaving directory '/root/nagios/Nagios-Plugins'
make: *** [Makefile:65: build] Error 2
```