### PR TITLE
updated HariSekhonUtils.pm allow vlans in isInterface

### DIFF
--- a/HariSekhonUtils.pm
+++ b/HariSekhonUtils.pm
@@ -2183,9 +2183,16 @@ sub isInt ($;$) {
 sub isInterface ($) {
     my $interface = shift;
     defined($interface) || return;
+    my $vlan;
+    ($interface, $vlan) = split(/\./, $interface);
+    $interface = isAlNum($interface) or return;
+    if ($vlan) {
+        isInt($vlan) or return;
+        ($vlan > 0 && $vlan < 4095) or return;
+        $interface .= "." . $vlan
+    }
     # TODO: consider checking if the interface actually exists on the system
-    $interface =~ /^((?:em|eth|bond|lo|docker)\d+|lo|veth[A-Fa-f0-9]+)$/ or return;
-    return $1;
+    return $interface;
 }
 
 
@@ -3681,7 +3688,7 @@ sub validate_int ($$;$$) {
 sub validate_interface ($) {
     my $interface = shift;
     defined($interface) || usage "interface not defined";
-    $interface = isInterface($interface) || usage "invalid interface defined: must be either eth<N>, bond<N> or lo<N>";
+    $interface = isInterface($interface) || usage "invalid interface defined: must be either alfanumeric or alfanumber.number";
     vlog_option("interface", $interface);
     return $interface;
 }

--- a/t/HariSekhonUtils.t
+++ b/t/HariSekhonUtils.t
@@ -666,11 +666,12 @@ is(validate_integer(6,"six",5,7),    6,  'validate_integer(6,"six",5,7)');
 
 # ============================================================================ #
 is(isInterface("eth0"),     "eth0",     'isInterface("eth0")');
+is(isInterface("eth0.100"), "eth0.100", 'isInterface("eth0.100")');
 is(isInterface("bond3"),    "bond3",    'isInterface("bond3")');
 is(isInterface("lo"),       "lo",       'isInterface("lo")');
 is(isInterface("docker0"),  "docker0",  'isInterface("docker0")');
 is(isInterface("vethfa1b2c3"), "vethfa1b2c3", 'isInterface("vethfa1b2c3")');
-ok(!isInterface("vethfa1b2z3"), 'isInterface("vethfa1b2z3")');
+is(isInterface("vethfa1b2c3.100"), "vethfa1b2c3.100", 'isInterface("vethfa1b2c3.100")');
 ok(!isInterface('b@interface'), '!isInterface(\'b@dinterface\'');
 
 is(validate_interface("eth0"),     "eth0",     'validate_interface("eth0")');


### PR DESCRIPTION
This PR modifies isInterface() to allow any alfanumeric interface name with vlan suffix (ie. eth0.100).